### PR TITLE
Wrap error.message with ternary value check

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -127,7 +127,7 @@ switch(command) {
 			if (error.data) {
 				console.error(chalk.red(`Error from test service: ${error.data.message}`))
 			}
-			if (error.message.includes('ECONNREFUSED')) {
+			if ((error.message || '').includes('ECONNREFUSED')) {
 				console.error(chalk.red(`Error connecting to ${configuration.testService}`))
 			}
 			else {

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pixel-perfect-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixel-perfect-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Visual regression testing tool cli",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
error doesn't always have `message`, so `includes()` throws error